### PR TITLE
#40 Option to filter by thread title in read-many endpoint

### DIFF
--- a/app/api/threads.py
+++ b/app/api/threads.py
@@ -39,9 +39,10 @@ def read_many_thread():
     def func(data, _):
         page = data.get("page", 1)
         per_page = data.get("perPage", 10)
+        search = data.get("search", "")
 
         # Get a paginated list of thread objects according to parameters
-        query = db.select(ThreadModel)
+        query = db.select(ThreadModel).filter(ThreadModel.title.contains(search))
         queried_threads = db.paginate(query, page=page, per_page=per_page).items
 
         # Return query result to client
@@ -52,6 +53,7 @@ def read_many_thread():
 read_many_thread_schema = {
     "page": {"type": "int", "required": False},
     "perPage": {"type": "int", "required": False},
+    "search": {"type": "text", "required": False}
 }
 
 @api_bp.route('/threads/<int:thread_id>', methods=['GET'])

--- a/tests/test_api_thread.py
+++ b/tests/test_api_thread.py
@@ -219,6 +219,38 @@ class TestReadMany(BaseApiTest):
         self.assertEqual(res_json_data[4]["description"], 'description5', f"Json data sent back is '{res_json_data[4]["description"]}'")
         self.assertEqual(res_json_data[9]["title"], 'thread10', f"Json data sent back is '{res_json_data[9]["title"]}'")
 
+    def test_get_with_search(self):
+        # Create a sizable number more threads directly with the database
+        for i in range(3, 12):
+            new_thread = ThreadModel(
+                title=f'thread{i}',
+                description=f'description{i}',
+                user_id=1
+            )
+            db.session.add(new_thread)
+        db.session.commit()
+
+        # The endpoint curently only supports searches for the title of the threads
+
+        # Post a get request for threads with 'thread' in the title
+        res = self.client.get("/api/threads?search=thread", headers=get_api_headers())
+        self.assertEqual(res.status_code, 200, f"Status code is wrong with message '{res.data}'")
+
+        # Check that the threads with 'thread' in the title are returned with the right information
+        res_json_data = json.loads(res.data)
+        self.assertEqual(len(res_json_data), 9, f"Data sent back is of length '{len(res_json_data)}")
+        self.assertEqual(res_json_data[0]["title"], 'thread3', f"Json data sent back is '{res_json_data[0]["title"]}'")
+        self.assertEqual(res_json_data[8]["title"], 'thread11', f"Json data sent back is '{res_json_data[8]["title"]}'")
+
+        # Post a get request for threads with '5' in the description
+        res = self.client.get("/api/threads?search=5", headers=get_api_headers())
+        self.assertEqual(res.status_code, 200, f"Status code is wrong with message '{res.data}'")
+
+        # Check that the thread with '5' in the title is returned with the right information
+        res_json_data = json.loads(res.data)
+        self.assertEqual(len(res_json_data), 1, f"Data sent back is of length '{len(res_json_data)}")
+        self.assertEqual(res_json_data[0]["title"], 'thread5', f"Json data sent back is '{res_json_data[0]["title"]}'")
+
 class TestReadById(BaseApiTest):
     """Tests threads read by id endpoint - GET api/threads/{id}"""
 


### PR DESCRIPTION
Passing in the query parameter "search=..." now makes read-many only return threads with titles that contain the search string.