### PR TITLE
#49 User as relationship in threads and comments

### DIFF
--- a/app/models/comments.py
+++ b/app/models/comments.py
@@ -31,6 +31,6 @@ class CommentModel(db.Model):
             'threadId': self.thread_id,
             'createdAt': self.created_at,
             'commentText': self.comment_text,
-            'userName': self.user.username,
+            'user': self.user.to_json(),
         }
         return json_comment

--- a/app/models/threads.py
+++ b/app/models/threads.py
@@ -31,8 +31,7 @@ class ThreadModel(db.Model):
             'title': self.title,
             'description': self.description,
             'createdAt': self.created_at,
-            'userId': self.user_id,
-            'userName': self.user.username,
+            'user': self.user.to_json(),
             'children': [c.to_json() for c in self.children],
         }
         return json_thread

--- a/tests/test_api_comments.py
+++ b/tests/test_api_comments.py
@@ -162,11 +162,11 @@ class TestReadMany(BaseApiTest):
 
         self.assertEqual(res_json_data[0]["commentText"], 'Do you have any with rank above B? I will trade', f"Json data sent back is '{res_json_data[0]["commentText"]}'")
         self.assertEqual(res_json_data[0]["threadId"], 1, f"Json data sent back is '{res_json_data[0]["threadId"]}'")
-        self.assertEqual(res_json_data[0]["userId"], 1, f"Json data sent back is '{res_json_data[0]["userId"]}'")
+        self.assertEqual(res_json_data[0]["user"]["id"], 1, f"Json data sent back is '{res_json_data[0]["user"]}'")
 
         self.assertEqual(res_json_data[1]["commentText"], "If u like anything in my inventory I'm down to trade", f"Json data sent back is '{res_json_data[1]["commentText"]}'")
         self.assertEqual(res_json_data[1]["threadId"], 1, f"Json data sent back is '{res_json_data[1]["threadId"]}'")
-        self.assertEqual(res_json_data[1]["userName"], "test", f"Json data sent back is '{res_json_data[1]["userName"]}'")
+        self.assertEqual(res_json_data[1]["user"]["username"], "test", f"Json data sent back is '{res_json_data[1]["user"]}'")
 
     def test_get_from_no_comments_thread(self):
         """Tests that getting with no comments gets an empty list"""

--- a/tests/test_api_thread.py
+++ b/tests/test_api_thread.py
@@ -147,11 +147,11 @@ class TestReadMany(BaseApiTest):
 
         self.assertEqual(res_json_data[0]["title"], 'hello', f"Json data sent back is '{res_json_data[0]["title"]}'")
         self.assertEqual(res_json_data[0]["description"], 'Heya new here', f"Json data sent back is '{res_json_data[0]["description"]}'")
-        self.assertEqual(res_json_data[0]["userName"], "test", f"Json data sent back is '{res_json_data[0]["userName"]}'")
+        self.assertEqual(res_json_data[0]["user"]["username"], "test", f"Json data sent back is '{res_json_data[0]["user"]}'")
 
         self.assertEqual(res_json_data[1]["title"], 'Theory', f"Json data sent back is '{res_json_data[1]["title"]}'")
         self.assertEqual(res_json_data[1]["description"], 'Just a theory a game theory', f"Json data sent back is '{res_json_data[1]["description"]}'")
-        self.assertEqual(res_json_data[1]["userName"], "test", f"Json data sent back is '{res_json_data[1]["userName"]}'")
+        self.assertEqual(res_json_data[1]["user"]["username"], "test", f"Json data sent back is '{res_json_data[1]["user"]}'")
 
     def test_get_from_empty_database(self):
         # Empty the database
@@ -297,7 +297,7 @@ class TestReadById(BaseApiTest):
         res_json_data = json.loads(res.data)
         self.assertEqual(res_json_data["title"], 'hello', f"Json data sent back is '{res_json_data["title"]}'")
         self.assertEqual(res_json_data["description"], 'Heya new here', f"Json data sent back is '{res_json_data["description"]}'")
-        self.assertEqual(res_json_data["userName"], "test", f"Json data sent back is '{res_json_data["userName"]}'")
+        self.assertEqual(res_json_data["user"]["id"], 1, f"Json data sent back is '{res_json_data["user"]}'")
 
         # Post a get request for second thread
         res = self.client.get("/api/threads/2", headers=get_api_headers())
@@ -307,7 +307,7 @@ class TestReadById(BaseApiTest):
         res_json_data = json.loads(res.data)
         self.assertEqual(res_json_data["title"], 'Theory', f"Json data sent back is '{res_json_data}'")
         self.assertEqual(res_json_data["description"], 'Just a theory a game theory', f"Json data sent back is '{res_json_data}'")
-        self.assertEqual(res_json_data["userName"], "test", f"Json data sent back is '{res_json_data["userName"]}'")
+        self.assertEqual(res_json_data["user"]["username"], "test", f"Json data sent back is '{res_json_data["user"]}'")
 
     def test_get_nonexistent_thread(self):
         """Tests that getting with a nonexistent thread ids gets the right error response"""


### PR DESCRIPTION
* Added user as a db relationship in both thread and comments models
* userId is still being sent back. Some tests were changed just to see that userName is now being sent back properly. 

Will unblock #12