### PR TITLE
Changed flask-migrate version in requirements.txt to the one that was working

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ blinker==1.7.0
 click==8.1.7
 dill==0.3.8
 Flask==3.0.2
-Flask-Migrate==4.0.7
+Flask-Migrate==3.1.0
 Flask-SQLAlchemy==3.1.1
 isort==5.13.2
 itsdangerous==2.1.2


### PR DESCRIPTION
I was using an older version of flask-migrate since the newer one was giving me trouble. Somehow this was not reflected when I did pip freeze.