### PR TITLE
Fixes format time functions to use local time

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,3 +1,4 @@
 """Blueprint for the main parts of the app"""
 
 from .views import main_bp
+from .template_filters import date_from_iso, time_from_iso

--- a/app/main/template_filters.py
+++ b/app/main/template_filters.py
@@ -1,0 +1,17 @@
+"""Custom template filters for the main blueprint."""
+
+from datetime import datetime, timedelta
+
+from .views import main_bp
+
+@main_bp.app_template_filter('date_from_iso')
+def date_from_iso(iso: datetime) -> str:
+    """Converts date to a string in the format DDD, DD MMM"""
+
+    return (iso + timedelta(hours=8)).strftime('%a, %d %b')
+
+@main_bp.app_template_filter('time_from_iso')
+def time_from_iso(iso: datetime) -> str:
+    """Converts time to a string in the format HH:MM:SS"""
+
+    return (iso + timedelta(hours=8)).strftime('%H:%M:%S')

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -7,7 +7,6 @@ from app.models.inventory import INVENTORY_CATEGORIES
 
 main_bp = Blueprint('main_bp', __name__)
 
-
 @main_bp.route("/")
 def home_page():
     """The home page"""

--- a/app/static/js/helpers/format_time.js
+++ b/app/static/js/helpers/format_time.js
@@ -1,7 +1,7 @@
 export function dateFromPythonTime(time) {
-    return time.split(" 202")[0]
+    return new Date(time).toDateString().split(" ").slice(0, 3).join(" ");
 }
 
 export function timeFromPythonTime(time) {
-    return time.split(" 202")[1].substring(1).split(" GMT")[0]
+    return new Date(time).toTimeString().split(" ").at(0);
 }

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -48,8 +48,8 @@
                         {% for i in posts %}
                             <li>
                                 <div class="timeline-time">
-                                    <span class="date">{{ i.created_at.date() }}</span>
-                                    <span class="time">{{ i.created_at.time().hour }}:{{ "0" if i.created_at.time().minute <=10 else "" }}{{ i.created_at.time().minute }}</span>
+                                    <span class="date">{{ i.created_at | date_from_iso }}</span>
+                                    <span class="time">{{ i.created_at | time_from_iso }}</span>
                                 </div>
                                 <div class="timeline-body">
                                     <div class="timeline-header">

--- a/app/templates/thread.html
+++ b/app/templates/thread.html
@@ -30,8 +30,8 @@
                             {% for i in comments %}
                                 <li>
                                     <div class="timeline-time">
-                                        <span class="date">{{ i.created_at.date() }}</span>
-                                        <span class="time">{{ i.created_at.time().hour.__str__().zfill(2) }}:{{ i.created_at.time().minute.__str__().zfill(2) }}</span>
+                                        <span class="date">{{ i.created_at | date_from_iso }}</span>
+                                        <span class="time">{{ i.created_at | time_from_iso }}</span>
                                     </div>
                                     <div class="timeline-body">
                                         <div class="timeline-content">


### PR DESCRIPTION
Overview:
- Converting into a date then into a local string takes into account your current timezone rather than just slicing the string

Closes #100 